### PR TITLE
Support controllers in any namespace.

### DIFF
--- a/grails-app/services/spud/core/AdminApplicationService.groovy
+++ b/grails-app/services/spud/core/AdminApplicationService.groovy
@@ -46,7 +46,7 @@ class AdminApplicationService {
 		rtn.name      = annotation.name()
 		rtn.thumbnail = annotation.thumbnail()
 		rtn.order     = annotation.order().toInteger()
-		rtn.url       = [controller: controllerClass.logicalPropertyName, action: 'index']
+		rtn.url       = [controller: controllerClass.logicalPropertyName, action: 'index', namespace: controllerClass.getPropertyValue('namespace') ?: 'spud_admin']
 		return rtn
 	}
 }

--- a/grails-app/views/spud/admin/dashboard/index.gsp
+++ b/grails-app/views/spud/admin/dashboard/index.gsp
@@ -8,7 +8,7 @@
     <div class="sortable row">
       <g:each in="${adminApplications}" var="adminApplication" status="index">
         <div class="admin_application col-md-2 col-sm-3 col-xs-6" id="application_name_${adminApplication.name}">
-          <g:link controller="${adminApplication.url.controller}" action="${adminApplication.url.action}" namespace="spud_admin">
+          <g:link controller="${adminApplication.url.controller}" action="${adminApplication.url.action}" namespace="${adminApplication.url.namespace}">
             <div class="image_wrapper"><asset:image src="${adminApplication.thumbnail}"/></div>
             <span class="application_name">${adminApplication.name}</span>
           </g:link>


### PR DESCRIPTION
Would seem, for porting reasons namely, that controllers using any
namespace should be supported in Spud.  Namespace-less and 'spud_admin'
controllers seem to work but not controllers in other namespaces.

Defaults to using the 'spud_admin' namespace if none is specified, which
preserves the current behavior.  Only difference is if any namespace is
provided it will be used instead of 'spud_admin.'
